### PR TITLE
Changed thunderbit heroku HTTP URL

### DIFF
--- a/_posts/2016-2-6-how-we-make-thunderbit.md
+++ b/_posts/2016-2-6-how-we-make-thunderbit.md
@@ -9,7 +9,7 @@ Our source code is free [(as in freedom)](http://www.gnu.org/philosophy/philosop
 
 We test our code locally, and in the cloud via [Travis CI](https://travis-ci.org/thunderbit/thunderbit). This continuous integration tool is a neutral place to test our changes and avoid errors like the classic "It works on my computer".
 
-Last, but not least, we have [a running instance](http://thunderbit.heroku-app.com) of the application at [Heroku](https://heroku.com). This instance is connected to an [Amazon S3](http://aws.amazon.com/s3) bucket to store the uploaded files, and to a [MongoDB](http://mongodb.org) database at [MongoLab](http://mongolab.com).
+Last, but not least, we have [a running instance](http://thunderbit.herokuapp.com) of the application at [Heroku](https://heroku.com). This instance is connected to an [Amazon S3](http://aws.amazon.com/s3) bucket to store the uploaded files, and to a [MongoDB](http://mongodb.org) database at [MongoLab](http://mongolab.com).
 
 In short:
 


### PR DESCRIPTION
Changed thunderbit heroku HTTP URL to: http://thunderbit.herokuapp.com.

Here is my DNS query log:

```
X@Y:~$ dig thunderbit.herokuapp.com

; <<>> DiG 9.9.5-3ubuntu0.7-Ubuntu <<>> thunderbit.herokuapp.com
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 47148
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 4, ADDITIONAL: 5

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;thunderbit.herokuapp.com.      IN      A

;; ANSWER SECTION:
thunderbit.herokuapp.com. 60    IN      A       46.137.183.180

;; AUTHORITY SECTION:
herokuapp.com.          578     IN      NS      ns-662.awsdns-18.net.
herokuapp.com.          578     IN      NS      ns-505.awsdns-63.com.
herokuapp.com.          578     IN      NS      ns-1624.awsdns-11.co.uk.
herokuapp.com.          578     IN      NS      ns-1378.awsdns-44.org.

;; ADDITIONAL SECTION:
ns-505.awsdns-63.com.   6939    IN      A       205.251.193.249
ns-662.awsdns-18.net.   166265  IN      A       205.251.194.150
ns-1378.awsdns-44.org.  166272  IN      A       205.251.197.98
ns-1624.awsdns-11.co.uk. 166272 IN      A       205.251.198.88

;; Query time: 37 msec
;; SERVER: XXX.XXX.XXX.XXX#53(XXX.XXX.XXX.XXX)
;; WHEN: Mon Feb 08 20:36:26 EET 2016
;; MSG SIZE  rcvd: 270

X@Y:~$ dig thunderbit.heroku-app.com

; <<>> DiG 9.9.5-3ubuntu0.7-Ubuntu <<>> thunderbit.heroku-app.com
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 54453
;; flags: qr rd ra ad; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;thunderbit.heroku-app.com.     IN      A

;; ANSWER SECTION:
thunderbit.heroku-app.com. 488  IN      A       5.39.99.50

;; Query time: 4 msec
;; SERVER: XXX.XXX.XXX.XXX#53(XXX.XXX.XXX.XXX)
;; WHEN: Mon Feb 08 20:36:32 EET 2016
;; MSG SIZE  rcvd: 59
```
